### PR TITLE
Add set timeout fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@Lumen5/react-flip-move",
+  "name": "lumen5-react-flip-move",
   "version": "3.0.6",
   "description": "Effortless animation between DOM changes (eg. list reordering) using the FLIP technique.",
   "main": "dist/react-flip-move.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-flip-move",
-  "version": "3.0.5",
+  "name": "@Lumen5/react-flip-move",
+  "version": "3.0.6",
   "description": "Effortless animation between DOM changes (eg. list reordering) using the FLIP technique.",
   "main": "dist/react-flip-move.cjs.js",
   "module": "dist/react-flip-move.es.js",

--- a/src/FlipMove.js
+++ b/src/FlipMove.js
@@ -470,6 +470,7 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
     }
 
     let called = false;
+    let timeoutId;
     // The onFinish callback needs to be bound to the transitionEnd event.
     // We also need to unbind it when the transition completes, so this ugly
     // inline function is required (we need it here so it closes over
@@ -497,18 +498,16 @@ class FlipMove extends Component<ConvertedProps, FlipMoveState> {
 
     domNode.addEventListener(transitionEnd, transitionEndHandler);
 
-    let { delay, duration } = props;
-    const { staggerDurationBy, staggerDelayBy, easing } = props;
+    let { delay, duration } = this.props;
+    const { staggerDurationBy, staggerDelayBy } = this.props;
 
     delay += index * staggerDelayBy;
     duration += index * staggerDurationBy;
 
-    const timeoutId = window.setTimeout(() => {
+    timeoutId = window.setTimeout(() => {
       if (!called) {
-        const event = new Event();
-        event.target = domNode;
-
-        transitionEndHandler(event);
+        const event = new Event(transitionEnd);
+        domNode.dispatchEvent(event);
       }
     }, delay + duration);
   }


### PR DESCRIPTION
FlipMove relies on the `transitionend` event to know when a transition has ended, and thus call the `onFinish` and `onFinishAll` callbacks. However, in some cases, the `transitionend` event doesn't fire. This means that FlipMove gets into a broken state, where `remainingAnimations` never goes back to 0. Thus an animation will never fully complete, and FlipMove will entirely stop working.

I believe this happens when the list or element components are re-rendered really fast, and FlipMove doesn't do quite the correct reconciling to know which elements are mid-transition. 

To solve this, I am taking a page out of react-bootstrap's playbook, and using `setTimeout` as a fallback to make sure that the `transitionend` event is definitely fired.

https://github.dev/react-bootstrap/dom-helpers

